### PR TITLE
Fix equip event firing when event doesn't go through

### DIFF
--- a/src/com/codingforcookies/armorequip/ArmorListener.java
+++ b/src/com/codingforcookies/armorequip/ArmorListener.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.PlayerDeathEvent;

--- a/src/com/codingforcookies/armorequip/ArmorListener.java
+++ b/src/com/codingforcookies/armorequip/ArmorListener.java
@@ -105,7 +105,7 @@ public class ArmorListener implements Listener{
 	}
 
     @EventHandler(
-            priority = EventPriority.MONITOR,
+            priority = EventPriority.HIGHEST,
             ignoreCancelled = true
     )
 	public void playerInteractEvent(PlayerInteractEvent e){

--- a/src/com/codingforcookies/armorequip/ArmorListener.java
+++ b/src/com/codingforcookies/armorequip/ArmorListener.java
@@ -111,7 +111,7 @@ public class ArmorListener implements Listener{
 		if(e.getAction() == Action.PHYSICAL) return;
 		if(e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK){
 			final Player player = e.getPlayer();
-			if(e.getClickedBlock() != null && e.getAction() == Action.RIGHT_CLICK_BLOCK){// Having both of these checks is useless, might as well do it though.
+			if(e.getClickedBlock() != null && e.getAction() == Action.RIGHT_CLICK_BLOCK && !player.isSneaking()){// Having both of these checks is useless, might as well do it though.
 				// Some blocks have actions when you right click them which stops the client from equipping the armor in hand.
 				Material mat = e.getClickedBlock().getType();
 				for(String s : blockedMaterials){

--- a/src/com/codingforcookies/armorequip/ArmorListener.java
+++ b/src/com/codingforcookies/armorequip/ArmorListener.java
@@ -103,7 +103,10 @@ public class ArmorListener implements Listener{
 		}
 	}
 
-	@EventHandler
+    @EventHandler(
+            priority = EventPriority.MONITOR,
+            ignoreCancelled = true
+    )
 	public void playerInteractEvent(PlayerInteractEvent e){
 		if(e.getAction() == Action.PHYSICAL) return;
 		if(e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK){


### PR DESCRIPTION
This is currently broken on all versions of this plugin. Armor events are fired infinitely if the player has their interact cancelled by another plugin.