### PR TITLE
Add PLAYER_HEAD as helmet for 1.13+ servers.

### DIFF
--- a/src/com/codingforcookies/armorequip/ArmorType.java
+++ b/src/com/codingforcookies/armorequip/ArmorType.java
@@ -25,7 +25,7 @@ public enum ArmorType{
 	public static ArmorType matchType(final ItemStack itemStack){
 		if(ArmorListener.isAirOrNull(itemStack)) return null;
 		String type = itemStack.getType().name();
-		if(type.endsWith("_HELMET") || type.endsWith("_SKULL")) return HELMET;
+		if(type.endsWith("_HELMET") || type.endsWith("_SKULL") || type.endsWith("PLAYER_HEAD")) return HELMET;
 		else if(type.endsWith("_CHESTPLATE") || type.endsWith("ELYTRA")) return CHESTPLATE;
 		else if(type.endsWith("_LEGGINGS")) return LEGGINGS;
 		else if(type.endsWith("_BOOTS")) return BOOTS;


### PR DESCRIPTION
This fixes `PLAYER_HEAD` items not being registered when clicked into the helmet slot. the `_SKULL` was for 1.12.2- and `PLAYER_HEAD` was added for 1.13+.